### PR TITLE
implement scrum-28

### DIFF
--- a/crud/customer.py
+++ b/crud/customer.py
@@ -21,6 +21,7 @@ def create_customer(db: Session, customer: CustomerCreate) -> Customer:
         raise HTTPException(status_code=400, detail={"errCode": 400, "errMsg": "Email already exists"})
     hashed_password = get_password_hash(customer.password)
     db_customer = Customer(**customer.dict(exclude={"password"}), hashed_password=hashed_password)
+    # Commit to db
     db.add(db_customer)
     db.commit()
     db.refresh(db_customer)

--- a/tests/customer/scrum-78.py
+++ b/tests/customer/scrum-78.py
@@ -1,0 +1,35 @@
+import pytest
+import requests
+
+@pytest.mark.parametrize("payload, expected_status, expected_response", [
+    (
+        {
+            "first_name": "John",
+            "last_name": "Doe",
+            "email": "invalid-email-format"
+        },
+        400,
+        {
+            "errorCode": "400",
+            "errorMsg": "Invalid email format"
+        }
+    )
+])
+def test_invalid_email_format(api_base_url, auth_token, payload, expected_status, expected_response):
+    url = f"{api_base_url}/customer/"
+    headers = {
+        "Authorization": f"Bearer {auth_token}",
+        "Content-Type": "application/json"
+    }
+
+    response = requests.post(url, json=payload, headers=headers)
+
+    # Assert status code
+    assert response.status_code == expected_status, f"Expected {expected_status}, got {response.status_code}"
+
+    # Assert response schema
+    response_json = response.json()
+    assert response_json == expected_response, f"Expected {expected_response}, got {response_json}"
+
+    # Assert SLA
+    assert response.elapsed.total_seconds() <= 3, f"SLA exceeded: {response.elapsed.total_seconds()}s"


### PR DESCRIPTION
**Context/background:**

Retail platforms must provide functionality to onboard new customers by allowing registration.

**Description:**

As an admin, I want to create new customer records so that they can start using the platform's services.

**Acceptance Criteria:**

- The customer must have a first name, last name, and email.

- Inputs must conform to the CustomerCreate schema.

- User must be authenticated and authorized.

**Technical Requirements:**

- Endpoint: /customer/

- HTTP Method: POST

**Implementation:**

- Validate inputs against CustomerCreate schema.

Return the newly created customer object using CustomerOut.